### PR TITLE
Handling unquoted codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+# jetbrain related directories/files
+.idea/

--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ function mdls(file, args, ready) {
   if (typeof args !== 'string') {
       ready = args;
   }
-  file = path.resolve(file).replace(/ /g, '\\ ')
+  file = path.resolve(file)
+      .replace(/ /g, '\\ ')
+      .replace(/\(/g, '\\(')
+      .replace(/\)/g, '\\)')
 
   return new Promise((resolve, reject) => {
       exec('mdls ' + (args ? args + ' ' : '') + file, function(err, raw_data) {

--- a/index.js
+++ b/index.js
@@ -69,12 +69,6 @@ function to_js_type(key) {
       return value.slice(1, -1)
     }
 
-    // handle cases like `("H.264",AAC)` where AAC doesn't
-    // get wrapped with double-quotes
-    if (/[a-zA-Z]+/.test(value)) {
-      return value;
-    }
-
     const as_num = +value
 
     if(!isNaN(as_num)) {
@@ -83,11 +77,17 @@ function to_js_type(key) {
 
     const as_date = new Date(value)
 
-    if(isNaN(as_date.getTime())) {
-      bad_value(key, value)
+    if(!isNaN(as_date.getTime())) {
+      return as_date
     }
 
-    return as_date
+    // handle cases like `("H.264",AAC)` where AAC doesn't
+    // get wrapped with double-quotes
+    if (/[a-zA-Z]+/.test(value)) {
+      return value
+    }
+
+    bad_value(key, value)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,12 @@ function to_js_type(key) {
       return value.slice(1, -1)
     }
 
+    // handle cases like `("H.264",AAC)` where AAC doesn't
+    // get wrapped with double-quotes
+    if (/[a-zA-Z]+/.test(value)) {
+      return value;
+    }
+
     const as_num = +value
 
     if(!isNaN(as_num)) {


### PR DESCRIPTION
sometimes `mdls` returns unquoted codec names, i.e. `("H.264",AAC)`, so instead of failing the parsing process completely, we better try looking for Alphabet characters in it and return them as value in case we managed to find at least one non-digit/valid Alphabet char.